### PR TITLE
Replace attach/detach with captureScreenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Multi-threaded screen recorder for [LOVE](https://love2d.org), made in LOVE, for
 
 * Multi-threaded
 * Can record multiple videos in a single launch of love
-* Can use different resolution/quality for recorded output
 * Supports mp4, mkv, webm formats
 * No audio
 
@@ -22,13 +21,9 @@ directory](https://love2d.org/wiki/love.filesystem) of your game.
 
 Here are the options/flags you can pass in `Peeker.start`:
 
-* `w` - **width** of the output. Defaults to size of the window.
-* `h` - **height** of the output. Defaults to size of the window.
-* `scale` - this overrides the `w` and `h` flags and is preferred to keep the aspect ratio of the output.
-* `fps` - **fps** of the output video. Defaults to `30`.
+* `fps` - **frames per second** of the output video. Defaults to `30`.
 * `out_dir` = name of the directory where the frames will be saved. Refer to the [wiki](https://love2d.org/wiki/love.filesystem) for the save directory location. Defaults to `recorder_xxxx` where `xxxx` is `os.time`.
 * `format` - either `"mp4"`, `"mkv"`, or `"webm"` for the format of the output video. Defaults to `mp4`
-* `overlay` - either `"text"` or `"circle"` to display when recording status is on.
 * `post_clean_frames` - if **true**, the `out_dir` will be deleted after the vide output is successfully encoded.
 
 ## DEPENDENCIES

--- a/main.lua
+++ b/main.lua
@@ -23,36 +23,37 @@ function love.update(dt)
 end
 
 function love.draw()
-	Peeker.attach()
-		love.graphics.clear(0, 0, 0, 1)
-		love.graphics.setColor(1, 0, 0, 1)
-		for _, c in ipairs(circles) do
-			love.graphics.circle(c.fill,
-				c.x + math.sin(timer) * 64 * c.dir,
-				c.y + math.cos(timer) * 64 * c.dir,
-				c.radius)
-		end
-		love.graphics.setColor(1, 1, 1, 1)
-		love.graphics.print("Frame recorded: " .. tostring(Peeker.get_current_frame()), 32, 64)
-	Peeker.detach()
+	love.graphics.clear(0, 0, 0, 1)
+	love.graphics.setColor(1, 0, 0, 1)
+	for _, c in ipairs(circles) do
+		love.graphics.circle(c.fill,
+			c.x + math.sin(timer) * 64 * c.dir,
+			c.y + math.cos(timer) * 64 * c.dir,
+			c.radius)
+	end
+	love.graphics.setColor(1, 1, 1, 1)
+	love.graphics.print("Frame recorded: " .. tostring(Peeker.get_current_frame()), 32, 64)
 end
 
 function love.keypressed(key)
 	if key == "r" then
-		if Peeker.get_status() then
-			Peeker.stop()
+		if love.keyboard.isDown('lshift', 'rshift') then
+			print("Peeker: Finalize recording. File: ", Peeker.get_out_dir())
+			Peeker.stop(true)
 		else
-			Peeker.start({
-				w = 320, --optional
-				h = 320, --optional
-				scale = 0.5, --this overrides w, h above, this is preferred to keep aspect ratio
-				-- n_threads = 2,
-				fps = 15,
-				out_dir = string.format("awesome_video"), --optional
-				-- format = "mkv", --optional
-				overlay = "circle", --or "text"
-				post_clean_frames = true,
-			})
+			if Peeker.get_status() then
+				print("Peeker: Stopped recording")
+				Peeker.stop()
+			else
+				print("Peeker: Started recording")
+				Peeker.start({
+						-- n_threads = 2,
+						fps = 15,
+						out_dir = string.format("awesome_video"), --optional
+						-- format = "mkv", --optional
+						post_clean_frames = true,
+					})
+			end
 		end
 	end
 end

--- a/peeker.lua
+++ b/peeker.lua
@@ -127,7 +127,8 @@ function Peeker.stop(finalize)
 	if not finalize then return end
 
 	local path = love.filesystem.getSaveDirectory() .. "/" .. OPT.out_dir
-	local flags, cmd = "", ""
+	local flags = ""
+	local cmd
 
 	if OPT.format == "mp4" then
 		flags = "-filter:v format=yuv420p -movflags +faststart"

--- a/peeker.lua
+++ b/peeker.lua
@@ -25,24 +25,31 @@ SOFTWARE.
 local Peeker = {}
 
 local DEF_FPS = 30
-local MAX_N_THREAD = love.system.getProcessorCount()
 local OS = love.system.getOS()
 
 local thread_code = [[
 require("love.image")
-local image_data, i, out_dir = ...
-local filename = string.format("%04d.png", i)
-filename = out_dir .. "/" .. filename
-local res = image_data:encode("png", filename)
-if res then
-	love.thread.getChannel("status"):push(i)
-else
-	print(i, res)
+local ch, out_dir = ...
+local i = 0
+while true do
+    i = i + 1
+    local image_data = ch:demand()
+    if image_data == "stop" then
+        break
+    end
+    local filename = string.format("%04d.png", i)
+    filename = out_dir .. "/" .. filename
+    local res = image_data:encode("png", filename)
+    if res then
+        love.thread.getChannel("status"):push(i)
+    else
+        print("peeker error", i, res)
+    end
 end
+love.thread.getChannel("status"):push("done")
 ]]
 
-local threads = {}
-local canvas
+local worker = {}
 local timer, cur_frame = 0, 0
 local is_recording = false
 
@@ -80,15 +87,6 @@ end
 
 function Peeker.start(opt)
 	assert(type(opt) == "table")
-	sassert(opt.w, type(opt.w) == "number" and opt.w > 0,
-		"opt.w must be a positive integer")
-	sassert(opt.h, type(opt.h) == "number" and opt.h > 0,
-		"opt.h must be a positive integer")
-	sassert(opt.scale, type(opt.scale) == "number")
-	sassert(opt.n_threads, type(opt.n_threads) == "number" and opt.n_threads > 0,
-		"opt.n_threads must be a positive integer")
-	sassert(opt.n_threads, opt.n_threads and opt.n_threads <= MAX_N_THREAD,
-		"opt.n_threads should not be > " .. MAX_N_THREAD .. " max available threads")
 	sassert(opt.fps, type(opt.fps) == "number" and opt.fps > 0,
 		"opt.fps must be a positive integer")
 	sassert(opt.out_dir, type(opt.out_dir) == "string",
@@ -96,37 +94,22 @@ function Peeker.start(opt)
 	sassert(opt.format, type(opt.format) == "string"
 		and within_itable(opt.format, supported_formats),
 		"opt.format must be either: " .. str_supported_formats)
-	sassert(opt.overlay, type(opt.overlay) == "string"
-		and (opt.overlay == "circle" or opt.overlay == "text"))
 	sassert(opt.post_clean_frames, type(opt.post_clean_frames) == "boolean")
 
 	OPT = opt
 
-	local ww, wh = love.graphics.getDimensions()
-	OPT.w = OPT.w or ww
-	OPT.h = OPT.h or wh
-	if OPT.scale then
-		OPT.orig_sx, OPT.orig_sy = 1/OPT.scale, 1/OPT.scale
-		OPT.sx, OPT.sy = OPT.scale, OPT.scale
-	else
-		OPT.orig_sx, OPT.orig_sy = ww/OPT.w, wh/OPT.h
-		OPT.sx, OPT.sy = OPT.w/ww, OPT.h/wh
-	end
-
-	OPT.n_threads = OPT.n_threads or MAX_N_THREAD
 	OPT.fps = OPT.fps or DEF_FPS
+	OPT.period = 1/OPT.fps
 	OPT.format = OPT.format or "mp4"
 	OPT.out_dir = OPT.out_dir or string.format("recording_" .. os.time())
-	OPT.flags = select(3, love.window.getMode())
 
 	OPT.out_dir = unique_filename(OPT.out_dir)
 	love.filesystem.createDirectory(OPT.out_dir)
 
-	for i = 1, OPT.n_threads do
-		threads[i] = love.thread.newThread(thread_code)
-	end
+	worker.thread = love.thread.newThread(thread_code)
+	worker.ch = love.thread.newChannel()
+	worker.thread:start(worker.ch, OPT.out_dir)
 
-	canvas = love.graphics.newCanvas(OPT.w, OPT.h)
 	cur_frame = 0
 	timer = 0
 	is_recording = true
@@ -136,6 +119,13 @@ function Peeker.stop(finalize)
 	sassert(finalize, type(finalize) == "boolean")
 	is_recording = false
 	if not finalize then return end
+
+	-- Wait for frames to finish writing.
+	local status
+	repeat
+		worker.ch:push("stop")
+		status = love.thread.getChannel("status"):demand()
+	until status == "done"
 
 	local path = Peeker.get_out_dir()
 	local flags = ""
@@ -180,64 +170,13 @@ end
 function Peeker.update(dt)
 	if not is_recording then return end
 	timer = timer + dt
-	local image_data = canvas:newImageData()
-	local found = false
-	for _, thread in ipairs(threads) do
-		if not thread:isRunning() then
-			thread:start(image_data, cur_frame, OPT.out_dir)
-			found = true
-			break
-		end
-
-		local err = thread:getError()
-		if err then
-			print(err)
-		end
-	end
-
-	if not found then
-		for _, thread in ipairs(threads) do
-			thread:wait()
-			break
-		end
+	if timer >= OPT.period then
+		timer = 0
+		love.graphics.captureScreenshot(worker.ch)
 	end
 
 	local status = love.thread.getChannel("status"):pop()
 	if status then cur_frame = cur_frame + 1 end
-end
-
-function Peeker.attach()
-	if not is_recording then return end
-	love.graphics.setCanvas({
-		canvas,
-		stencil = OPT.flags.stencil,
-		depth = OPT.flags.depth,
-	})
-	love.graphics.clear()
-	love.graphics.push()
-	love.graphics.scale(OPT.sx, OPT.sy)
-end
-
-function Peeker.detach()
-	if not is_recording then return end
-	local r, g, b, a = love.graphics.getColor()
-	love.graphics.pop()
-	love.graphics.setCanvas()
-	love.graphics.setColor(1, 1, 1)
-
-	love.graphics.push()
-	love.graphics.scale(OPT.orig_sx, OPT.orig_sy)
-	love.graphics.draw(canvas)
-	love.graphics.pop()
-
-	if OPT.overlay then
-		love.graphics.setColor(1, 0, 0, 1)
-		if OPT.overlay == "text" then
-			love.graphics.print("RECORDING", 4, 4)
-		elseif OPT.overlay == "circle" then
-			love.graphics.circle("fill", 12, 12, 8)
-		end
-	end
 end
 
 function Peeker.get_status() return is_recording end


### PR DESCRIPTION
This is a major change to Peeker's API and to it's feature set, so I totally understand if you want to close this PR. I saw captureScreenshot and thought it might be a good alternative to canvas rendering that would fix issues with push or anything else doing fancy stuff with your rendering.

----

Remove Peeker.attach/detach. Instead, use lg.captureScreenshot(channel)
to push requests to the thread. Now we use a single thread that handles
all of our screenshots. It may be a bit slow when we stop recording, but
the code is much simpler.

Actually record according to the requested framerate. This ensures our
output video matches the speed seen at record time (assuming the game is
running at or faster than the input framerate).

Adds Shift-r to finalize recording in demo code.

**Removes several features:**
* ability to adjust the w/h or scale of the recorded frames
* ability to add an overlay while recording
* using more than one background thread

Adds benefits:
* simpler api
* less work done on the main thread (Peeker.update is very simple now)
* works with advanced canvas use and resolution modifying libraries

Additionally fixes macos always deleting captures even though it doesn't convert them and failures to save video files twice in one execution.